### PR TITLE
Scope separator modification

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -17,6 +17,11 @@ class Provider extends AbstractProvider implements ProviderInterface
      * {@inheritdoc}
      */
     protected $scopes = ['https://www.googleapis.com/auth/youtube.readonly'];
+    
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
YouTube API requires a space to separate scopes with
