### PR TITLE
Fix for empty items array error in YouTube channel service response

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -54,6 +54,16 @@ class Provider extends AbstractProvider
                 ],
             ]
         );
+        
+        $contents = json_decode($response->getBody()->getContents(), true);
+        
+        if(!isset($contents['items'])) {
+           throw new \Exception('The channel you selected is not a valid channel..', 404);   
+        }
+        
+        if(empty($contents['items'])) {
+           throw new \Exception('The channel you selected is not found on YouTube.', 404);   
+        }
 
         return json_decode($response->getBody()->getContents(), true)['items'][0];
     }

--- a/Provider.php
+++ b/Provider.php
@@ -65,7 +65,7 @@ class Provider extends AbstractProvider
            throw new \Exception('The channel you selected is not found on YouTube.', 404);   
         }
 
-        return json_decode($response->getBody()->getContents(), true)['items'][0];
+        return $contents['items'][0];
     }
 
     /**


### PR DESCRIPTION
YouTube is now returning missing and/or empty items arrays in the response. YouTube used to create a channel automatically for your google account/gmail account so there was always an items array. This is no longer the case. Through trial and error we've found that a new or current google account/gmail account with no channels will still see an option to select that account. These selections are the ones that result in an empty items array error that users are experiencing.

https://stackoverflow.com/questions/62380001/callback-error-on-youtube-socialite-provider-for-laravel